### PR TITLE
development

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -73,7 +73,6 @@ locals {
       structured_run_output_enabled = true
       tags                          = ["source:aws", "env:dev", "aws_account_id:010062078576", "aws_region:us-east-1"]
       tfe_token                     = var.terraform_api_token
-      trigger_prefixes              = [""]
     }
   }
 }
@@ -96,7 +95,6 @@ module "workspace" {
   structured_run_output_enabled = each.value.structured_run_output_enabled
   tags                          = each.value.tags
   tfe_token                     = each.value.tfe_token
-  trigger_prefixes              = each.value.trigger_prefixes
 }
 /*
 module "variable_set" {


### PR DESCRIPTION
- Terraform Cloud - Default VPC workspaces
- Changed execution mode to local
- Added default value for account_id variable
- Adding VCS to workspace
- Changing job execution runs
- Committing changes to terraform-cloud-organization
- Changing runner to macos-latest
- trigger_prefixes removed
