### PR TITLE
development

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -73,6 +73,9 @@ locals {
       structured_run_output_enabled = true
       tags                          = ["source:aws", "env:dev", "aws_account_id:010062078576", "aws_region:us-east-1"]
       tfe_token                     = var.terraform_api_token
+      vcs_repository                = "sophos-iaas/terraform-aws-vpc"
+      vcs_branch                    = "main"
+      working_directory             = "/"
     }
   }
 }
@@ -95,6 +98,9 @@ module "workspace" {
   structured_run_output_enabled = each.value.structured_run_output_enabled
   tags                          = each.value.tags
   tfe_token                     = each.value.tfe_token
+  vcs_repository                = each.value.vcs_repository
+  vcs_branch                    = each.value.vcs_branch
+  working_directory             = each.value.working_directory
 }
 /*
 module "variable_set" {


### PR DESCRIPTION
- Terraform Cloud - Default VPC workspaces
- Changed execution mode to local
- Added default value for account_id variable
- Adding VCS to workspace
- Changing job execution runs
- Committing changes to terraform-cloud-organization
- Changing runner to macos-latest
- trigger_prefixes removed
- Terraform fmt
