### PR TITLE
development

### DIFF
--- a/.github/workflows/plan-apply-on-merge.yaml
+++ b/.github/workflows/plan-apply-on-merge.yaml
@@ -23,6 +23,8 @@ jobs:
   set_deployment_environment:
     name: deployment environment
     runs-on: ubuntu-latest
+    env:
+      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     steps:
       - name: Set env to development
         if: endsWith(github.ref, '/development')


### PR DESCRIPTION
- Terraform Cloud - Default VPC workspaces
- Changed execution mode to local
- Added default value for account_id variable
- Adding VCS to workspace
- Changing job execution runs
- Committing changes to terraform-cloud-organization
- Changing runner to macos-latest
- trigger_prefixes removed
- Terraform fmt
- Set working directory to us-east-1
- Adding init -upgrade to Plan and Apply
- Allow actions to set-env
