### PR TITLE
development

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -62,13 +62,13 @@ locals {
     "vpc-us-east-1" = {
       allow_destroy_plan            = true
       add_vcs_repo                  = true
-      auto_apply                    = false
+      auto_apply                    = true
       execution_mode                = "local"
       file_triggers_enabled         = false
       global_remote_state           = true
       name                          = "vpc-us-east-1"
       oauth_token_id                = data.terraform_remote_state.tfc_organization.outputs.oauth_client_id
-      queue_all_runs                = false
+      queue_all_runs                = true
       speculative_enabled           = false
       structured_run_output_enabled = true
       tags                          = ["source:aws", "env:dev", "aws_account_id:010062078576", "aws_region:us-east-1"]


### PR DESCRIPTION
- Terraform Cloud - Default VPC workspaces
- Changed execution mode to local
- Added default value for account_id variable
- Adding VCS to workspace
- Changing job execution runs
- Committing changes to terraform-cloud-organization
- Changing runner to macos-latest
- trigger_prefixes removed
- Terraform fmt
- Set working directory to us-east-1
- Adding init -upgrade to Plan and Apply
- Allow actions to set-env
- Changing auto-apply to true
