### PR TITLE
development

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -76,7 +76,7 @@ locals {
       queue_all_runs                = true
       speculative_enabled           = false
       structured_run_output_enabled = true
-      tags                          = ["source:aws", "env:dev", "aws_account_id:010062078576", "aws_region:us-east-1"]
+      tags                          = ["source:aws", "env:production", "aws_account_id:010062078576", "aws_region:us-east-1"]
       tfe_token                     = var.terraform_api_token
       vcs_repository                = "sophos-iaas/terraform-aws-vpc"
       vcs_branch                    = "main"
@@ -94,7 +94,7 @@ locals {
       queue_all_runs                = true
       speculative_enabled           = false
       structured_run_output_enabled = true
-      tags                          = ["source:aws", "env:dev", "aws_account_id:010062078576", "aws_region:us-east-2"]
+      tags                          = ["source:aws", "env:production", "aws_account_id:010062078576", "aws_region:us-east-2"]
       tfe_token                     = var.terraform_api_token
       vcs_repository                = "sophos-iaas/terraform-aws-vpc"
       vcs_branch                    = "main"
@@ -112,7 +112,7 @@ locals {
       queue_all_runs                = true
       speculative_enabled           = false
       structured_run_output_enabled = true
-      tags                          = ["source:aws", "env:dev", "aws_account_id:010062078576", "aws_region:us-west-1"]
+      tags                          = ["source:aws", "env:production", "aws_account_id:010062078576", "aws_region:us-west-1"]
       tfe_token                     = var.terraform_api_token
       vcs_repository                = "sophos-iaas/terraform-aws-vpc"
       vcs_branch                    = "main"
@@ -130,7 +130,7 @@ locals {
       queue_all_runs                = true
       speculative_enabled           = false
       structured_run_output_enabled = true
-      tags                          = ["source:aws", "env:dev", "aws_account_id:010062078576", "aws_region:us-west-2"]
+      tags                          = ["source:aws", "env:production", "aws_account_id:010062078576", "aws_region:us-west-2"]
       tfe_token                     = var.terraform_api_token
       vcs_repository                = "sophos-iaas/terraform-aws-vpc"
       vcs_branch                    = "main"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -80,7 +80,7 @@ locals {
       tfe_token                     = var.terraform_api_token
       vcs_repository                = "sophos-iaas/terraform-aws-vpc"
       vcs_branch                    = "main"
-      working_directory             = "./us-east-1"
+      working_directory             = "./us-east-1/vpc"
     },
     "vpc-us-east-2" = {
       allow_destroy_plan            = true
@@ -98,7 +98,7 @@ locals {
       tfe_token                     = var.terraform_api_token
       vcs_repository                = "sophos-iaas/terraform-aws-vpc"
       vcs_branch                    = "main"
-      working_directory             = "./us-east-2"
+      working_directory             = "./us-east-2/vpc"
     },
     "vpc-us-west-1" = {
       allow_destroy_plan            = true
@@ -116,7 +116,7 @@ locals {
       tfe_token                     = var.terraform_api_token
       vcs_repository                = "sophos-iaas/terraform-aws-vpc"
       vcs_branch                    = "main"
-      working_directory             = "./us-west-1"
+      working_directory             = "./us-west-1/vpc"
     },
     "vpc-us-west-2" = {
       allow_destroy_plan            = true
@@ -134,7 +134,7 @@ locals {
       tfe_token                     = var.terraform_api_token
       vcs_repository                = "sophos-iaas/terraform-aws-vpc"
       vcs_branch                    = "main"
-      working_directory             = "./us-west-2"
+      working_directory             = "./us-west-2/vpc"
     }
   }
 }


### PR DESCRIPTION
- Terraform Cloud - Default VPC workspaces
- Changed execution mode to local
- Added default value for account_id variable
- Adding VCS to workspace
- Changing job execution runs
- Committing changes to terraform-cloud-organization
- Changing runner to macos-latest
- trigger_prefixes removed
- Terraform fmt
- Set working directory to us-east-1
- Adding init -upgrade to Plan and Apply
- Allow actions to set-env
- Changing auto-apply to true
- TF Workspaces
- Terraform Docs Hook
- Changing workspace tags to production
